### PR TITLE
Missing comma in float-shadow in property scope

### DIFF
--- a/scss/effects/_float-shadow.scss
+++ b/scss/effects/_float-shadow.scss
@@ -19,7 +19,7 @@
 	  opacity: 0;
 	  background: radial-gradient(ellipse at center, rgba(0,0,0,.35) 0%,rgba(0,0,0,0) 80%); /* W3C */
 		transition-duration: $defaultDuration;
-		transition-property: transform opacity;
+		transition-property: transform, opacity;
 	}
 
 	&:hover {


### PR DESCRIPTION
The missing comma here prevented the transition-property from being properly scoped to only transform and opacity. Adding in this comma mitigates that.
