### PR TITLE
Added commas to all multiple transition properties

### DIFF
--- a/scss/effects/_curl-bottom-left.scss
+++ b/scss/effects/_curl-bottom-left.scss
@@ -22,7 +22,7 @@
 		);
 		box-shadow: 1px -1px 1px rgba(0, 0, 0, .4);
 		transition-duration: $defaultDuration;
-		transition-property: width height;
+		transition-property: width, height;
 	}
 
 	&:hover:before {

--- a/scss/effects/_curl-bottom-right.scss
+++ b/scss/effects/_curl-bottom-right.scss
@@ -22,7 +22,7 @@
 		);
 		box-shadow: -1px -1px 1px rgba(0, 0, 0, .4);
 		transition-duration: $defaultDuration;
-		transition-property: width height;
+		transition-property: width, height;
 	}
 
 	&:hover:before {

--- a/scss/effects/_curl-top-left.scss
+++ b/scss/effects/_curl-top-left.scss
@@ -25,7 +25,7 @@
 		z-index: 1000;
 		box-shadow: 1px 1px 1px rgba(0, 0, 0, .4);
 		transition-duration: $defaultDuration;
-		transition-property: width height;
+		transition-property: width, height;
 	}
 
 	&:hover:before {

--- a/scss/effects/_curl-top-right.scss
+++ b/scss/effects/_curl-top-right.scss
@@ -22,7 +22,7 @@
 		);
 		box-shadow: -1px 1px 1px rgba(0, 0, 0, .4);
 		transition-duration: $defaultDuration;
-		transition-property: width height;
+		transition-property: width, height;
 	}
 
 	&:hover:before {

--- a/scss/effects/_float-shadow.scss
+++ b/scss/effects/_float-shadow.scss
@@ -19,7 +19,7 @@
 	  opacity: 0;
 	  background: radial-gradient(ellipse at center, rgba(0,0,0,.35) 0%,rgba(0,0,0,0) 80%); /* W3C */
 		transition-duration: $defaultDuration;
-		transition-property: transform opacity;
+		transition-property: transform, opacity;
 	}
 
 	&:hover {

--- a/scss/effects/_hover-shadow.scss
+++ b/scss/effects/_hover-shadow.scss
@@ -47,7 +47,7 @@
 	  opacity: 0;
 	  background: radial-gradient(ellipse at center, rgba(0,0,0,.35) 0%,rgba(0,0,0,0) 80%); /* W3C */
 		transition-duration: $defaultDuration;
-		transition-property: transform opacity;
+		transition-property: transform, opacity;
 	}
 
 	&:hover {

--- a/scss/effects/_outline-inward.scss
+++ b/scss/effects/_outline-inward.scss
@@ -18,7 +18,7 @@
 		left: -($outerBorderWidth + $innerBorderWidth) * 2;
 		opacity: 0;
 		transition-duration: .3s;
-		transition-property: top right bottom left;
+		transition-property: top, right, bottom, left;
 	}
 
 	&:hover:before {

--- a/scss/effects/_outline-outward.scss
+++ b/scss/effects/_outline-outward.scss
@@ -17,7 +17,7 @@
 		bottom: 0;
 		left: 0;
 		transition-duration: .3s;
-		transition-property: top right bottom left;
+		transition-property: top, right, bottom, left;
 	}
 
 	&:hover:before {


### PR DESCRIPTION
When there are multiple transition-properites they should be comma separated. 
