### PR TITLE
Add active class

### DIFF
--- a/scss/effects/border-transitions/_underline-from-center.scss
+++ b/scss/effects/border-transitions/_underline-from-center.scss
@@ -23,7 +23,7 @@
 	&:hover,
 	&:focus,
 	&:active,
-	&.#{nameSpace}-active {
+	&.#{$nameSpace}-active {
 
 		&:before {
 			left: 0;

--- a/scss/effects/border-transitions/_underline-from-center.scss
+++ b/scss/effects/border-transitions/_underline-from-center.scss
@@ -22,7 +22,8 @@
 
 	&:hover,
 	&:focus,
-	&:active {
+	&:active,
+	&.#{nameSpace}-active {
 
 		&:before {
 			left: 0;


### PR DESCRIPTION
In our project we are using the underline-from-center animation when hovering over links in our navigation bar to add a little :sparkles:.  What we need though is a way to keep the final state of the animation active, so that we can underline the current page the user is on.  

I whipped together a quick test of it on just the effect we need and its working.  If you like the idea I can flesh out this PR and apply it across all the effects and the less files as well.

I could only include it if $includeClasses is true, or perhaps introduce a new variable to control its presence?