### PR TITLE
rename Hover.css => Hover in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hover.css",
+  "name": "Hover",
   "version": "2.0.2",
   "homepage": "http://ianlunn.github.io/Hover",
   "authors": [


### PR DESCRIPTION
I checked out the github page, saw the bower.json file and opened it and copy pasted the name into my terminal to install it but it failed:

```
bower install Hover.css
bower ENOTFOUND     Package Hover.css not found
```

I ran `bower search` and saw its called just Hover, so I installed it successfully w/ `bower install Hover`.

I forked the library to add a new feature and used bower's `link` command to point my app at my local copy instead of your copy that bower installed.  It couldn't find Hover though:

```
bower link Hover
bower ENOENT        Failed to create link to Hover

Additional error details:
/Users/mfrawley/.local/share/bower/Hover does not exist or points to a non-existent file
```

I looked inside that directory and saw that the directory was `Hover.css`, so `bower link Hover.css` worked successfully.

Seems like bower strips the `.css` out of the name for some commands but not all (probably a bug on their part), though its also confusing not being able to install from the name in the bower.json file, so I propose renaming it to just Hover.  Since the library is already installed as `bower install Hover`, I don't think this should affect normal usage.