### PR TITLE
Move dependency to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "grunt-contrib-less": "^1.0.0",
     "grunt-contrib-sass": "~0.6.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-version": "^0.3.0"
-  },
-  "dependencies": {
+    "grunt-version": "^0.3.0",
     "load-grunt-tasks": "~0.2.0"
   }
 }


### PR DESCRIPTION
`load-grunt-tasks` should be recorded as a devDependency with the other Grunt packages rather than as a dependency. This will make it so that when npm installs hover.css, `load-grunt-tasks` will not be installed unnecessarily.