### PR TITLE
Define entry points in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "bugs": {
     "url": "https://github.com/IanLunn/Hover/issues"
   },
+  "style": "css/hover.css",
+  "sass": "scss/hover.scss",
+  "main": "css/hover.css",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-connect": "~0.5.0",


### PR DESCRIPTION
Specifying the entry point will make this possible from a sass file:

``` sass
@import "hover.css";
```
also solves https://github.com/IanLunn/Hover/issues/94

for the `main` property, from [npm's documentation](https://docs.npmjs.com/files/package.json#main):

> The main field is a module ID that is the primary entry point to your program. That is, if your package is named foo, and a user installs it, and then does require("foo"), then your main module's exports object will be returned.

for the `style` property, copying from [this SO answer](https://stackoverflow.com/a/32042285/4330182):

----------

From Techwraith's [pull request][1] that added it to Bootstrap:

> Many modules in npm are starting to expose their css entry files in
> their package.json files. This allows tools like [`npm-css`][2],
> [`rework-npm`][3], and [`npm-less`][4] to import bootstrap from the
> node_modules directory. [...]

> It's actually not written anywhere but in the code for these modules
> right now. We're hoping to get this standardized at some point, but
> we've all reached this convention separately, so I'm inclined to just
> go with it. [...]

> If you want to read about this style of css development, I wrote a
> thing:
> 
> http://techwraith.com/your-css-needs-a-dependency-graph-too/

There's also support in other tools, such as the browserify plugin [parcelify][5]:

> Add css to your npm modules consumed with browserify.
> 
> * Just add a style key to your package.json to specify the package's css file(s). [...]
> 
> Parcelify will concatenate all the css files in the modules on which
> `main.js` depends -- in this case just `myModule.css` -- in the order
> of the js dependency graph, and write the output to `bundle.css`.


  [1]: https://github.com/twbs/bootstrap/pull/12441
  [2]: https://github.com/defunctzombie/npm-css
  [3]: https://github.com/conradz/rework-npm
  [4]: https://github.com/Raynos/npm-less
  [5]: https://github.com/rotundasoftware/parcelify

> github.com/postcss/postcss-import still uses the style property
