### PR TITLE
Edge bug fix for "From Centre" border transitions

### DIFF
--- a/css/hover.css
+++ b/css/hover.css
@@ -2184,7 +2184,7 @@
   content: "";
   position: absolute;
   z-index: -1;
-  left: 50%;
+  left: 51%;
   right: 50%;
   bottom: 0;
   background: #2098D1;
@@ -2275,7 +2275,7 @@
   content: "";
   position: absolute;
   z-index: -1;
-  left: 50%;
+  left: 51%;
   right: 50%;
   top: 0;
   background: #2098D1;


### PR DESCRIPTION
using 50% for left and right on leaves a tiny line on it's initial state in Edge (see http://ianlunn.github.io/Hover/). Setting this left 51% removes the line as the items then technically are 101% and overlap one another