### PR TITLE
fix: Invalid property value

### DIFF
--- a/css/demo-page.css
+++ b/css/demo-page.css
@@ -400,7 +400,6 @@ h3 {
   margin-top: 3em;
   padding-top: 3em;
   padding-bottom: 1em;
-  font-family: $fontFeature;
   font-size: 1.125em;
   text-align: center;
   line-height: 1.6;


### PR DESCRIPTION
## Issue
The CSS class `.made-by` has 1 invalid property value.
```diff
- font-family: $fontFeature;
```

## Fix
Remove the `font-family` property and the font will be inherited from `body` or `font-family` can be explicitly set to use a valid font.